### PR TITLE
fix folder path concatenation and exclude hidden files

### DIFF
--- a/bin2pcd_folder.py
+++ b/bin2pcd_folder.py
@@ -19,15 +19,18 @@ def bin_to_pcd(binFileName):
     pcd.points = o3d.utility.Vector3dVector(np_pcd)
     return pcd
 
+
 def main(binFolderName, pcdFolderName):
     for i in os.listdir(binFolderName):
-        binFileName = binFolderName+i
-        print(i)
+        if not i.startswith('.'):
+            binFileName = binFolderName + '/' + i
+            print(i)
 
-        pcd = bin_to_pcd(binFileName)
-        pcdFileName = pcdFolderName+i[:-4]+'.pcd'
-        print(pcdFileName)
-        o3d.io.write_point_cloud(pcdFileName, pcd)
+            pcd = bin_to_pcd(binFileName)
+            pcdFileName = pcdFolderName+i[:-4]+'.pcd'
+            print(pcdFileName)
+            o3d.io.write_point_cloud(pcdFileName, pcd)
+
 
 if __name__ == "__main__":
     a = sys.argv[1]


### PR DESCRIPTION
Hi Jinlai,

Thanks for creating this script for converting bin files to pcd files, it works great with the single file script, but I got some problems while running the folder script.

I've made some changes to:
1. exclude hidden files in source folder (files starting with .)
2. fix target path by adding '/'

Regards,
Shuai


